### PR TITLE
#21 issue fixed

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -8,7 +8,8 @@
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.VIBRATE"/>	
 
-	<application android:icon="@drawable/icon" android:label="@string/app_name" android:allowBackup="true">
+	<application android:icon="@drawable/icon" android:label="@string/app_name" android:allowBackup="true"
+	    android:name=".CalendarWeekdayLoader">
 		<!-- Splash and Main activities -->
 		<activity android:name=".SplashActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen" android:screenOrientation="portrait">
 			<intent-filter>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -9,7 +9,7 @@
 	<uses-permission android:name="android.permission.VIBRATE"/>	
 
 	<application android:icon="@drawable/icon" android:label="@string/app_name" android:allowBackup="true"
-	    android:name=".CalendarWeekdayLoader">
+	    android:name=".FestivalAppLoader">
 		<!-- Splash and Main activities -->
 		<activity android:name=".SplashActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen" android:screenOrientation="portrait">
 			<intent-filter>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -77,6 +77,15 @@
     <string name="service.Activities">Aktiviteetit</string>
     <string name="service.PhoneCharging">Kännykkälataus</string>
     
+    <!--  Calender Days -->
+    <string name="calendar.Monday">Maanantai</string>
+    <string name="calendar.Tuesday">Tiistai</string>
+    <string name="calendar.Wednesday">Keskiviikko</string>
+    <string name="calendar.Thursday">Torstai</string>
+    <string name="calendar.Friday">Perjantai</string>
+    <string name="calendar.Saturday">Lauantai</string>
+    <string name="calendar.Sunday">Sunnuntai</string>
+    
     <!-- General info -->
     <string name="generalInfo.FrequentlyAsked">Usein kysyttyä</string>
     <string name="generalInfo.OpenHours">Aukioloajat</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -76,6 +76,15 @@
     <string name="service.Activities">Activities</string>
     <string name="service.PhoneCharging">Phone charging</string>
     
+    <!--  Calender Days -->
+    <string name="calendar.Monday">Monday</string>
+    <string name="calendar.Tuesday">Tuesday</string>
+    <string name="calendar.Wednesday">Wednesday</string>
+    <string name="calendar.Thursday">Thursday</string>
+    <string name="calendar.Friday">Friday</string>
+    <string name="calendar.Saturday">Saturday</string>
+    <string name="calendar.Sunday">Sunday</string>
+    
     <!-- General info -->
     <string name="generalInfo.FrequentlyAsked">FAQ</string>
     <string name="generalInfo.OpenHours">Opening hours</string>

--- a/src/com/futurice/festapp/CalendarWeekdayLoader.java
+++ b/src/com/futurice/festapp/CalendarWeekdayLoader.java
@@ -1,0 +1,16 @@
+package com.futurice.festapp;
+
+import com.futurice.festapp.util.CalendarUtil;
+
+import android.app.Application;
+import android.content.Context;
+
+public class CalendarWeekdayLoader extends Application{
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        CalendarUtil.load(this);;
+    }
+
+}

--- a/src/com/futurice/festapp/FestivalAppLoader.java
+++ b/src/com/futurice/festapp/FestivalAppLoader.java
@@ -5,11 +5,13 @@ import com.futurice.festapp.util.CalendarUtil;
 import android.app.Application;
 import android.content.Context;
 
-public class CalendarWeekdayLoader extends Application{
+public class FestivalAppLoader extends Application{
 
     @Override
     public void onCreate() {
         super.onCreate();
+        
+        //Get weekdays names from resources
         CalendarUtil.load(this);;
     }
 

--- a/src/com/futurice/festapp/FestivalAppLoader.java
+++ b/src/com/futurice/festapp/FestivalAppLoader.java
@@ -12,7 +12,7 @@ public class FestivalAppLoader extends Application{
         super.onCreate();
         
         //Get weekdays names from resources
-        CalendarUtil.load(this);;
+        CalendarUtil.load(this);
     }
 
 }

--- a/src/com/futurice/festapp/util/CalendarUtil.java
+++ b/src/com/futurice/festapp/util/CalendarUtil.java
@@ -4,19 +4,21 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import com.futurice.festapp.R;
+import android.content.Context;
 
 public class CalendarUtil {
 	
 	private static final Map<Integer, String> weekDays = new HashMap<Integer, String>();
 	
-	static {
-		weekDays.put(Calendar.MONDAY, "Maanantai");
-		weekDays.put(Calendar.TUESDAY, "Tiistai");
-		weekDays.put(Calendar.WEDNESDAY, "Keskiviikko");
-		weekDays.put(Calendar.THURSDAY, "Torstai");
-		weekDays.put(Calendar.FRIDAY, "Perjantai");
-		weekDays.put(Calendar.SATURDAY, "Lauantai");
-		weekDays.put(Calendar.SUNDAY, "Sunnuntai");
+	public static void load(Context context) {
+		weekDays.put(Calendar.MONDAY, context.getResources().getString(R.string.calendar_Monday));
+		weekDays.put(Calendar.TUESDAY, context.getResources().getString(R.string.calendar_Tuesday));
+		weekDays.put(Calendar.WEDNESDAY, context.getResources().getString(R.string.calendar_Wednesday));
+		weekDays.put(Calendar.THURSDAY, context.getResources().getString(R.string.calendar_Thursday));
+		weekDays.put(Calendar.FRIDAY, context.getResources().getString(R.string.calendar_Friday));
+		weekDays.put(Calendar.SATURDAY, context.getResources().getString(R.string.calendar_Saturday));
+		weekDays.put(Calendar.SUNDAY, context.getResources().getString(R.string.calendar_Sunday));
 	}
 	
 	public static String getFullWeekdayName(int weekday) {


### PR DESCRIPTION
This is a fix to issue #21: weekdays are now fetched from "strings.xml". In order to obtain the context, class "ContextRetriever" was created. The Manifest was changed in order to allow this subclass of "Application" to be called before any other application component.
