### PR TITLE
Fixes issue #50

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -44,6 +44,9 @@
     		<intent-filter>
         		<action android:name="CHECK_ALARMS"/>
     		</intent-filter>
+    		<intent-filter >
+        		<action android:name="FORCE_DATA_LOAD"/>
+    		</intent-filter>
 		</receiver>
 	</application>
 </manifest>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -44,9 +44,6 @@
     		<intent-filter>
         		<action android:name="CHECK_ALARMS"/>
     		</intent-filter>
-    		<intent-filter >
-        		<action android:name="FORCE_DATA_LOAD"/>
-    		</intent-filter>
 		</receiver>
 	</application>
 </manifest>

--- a/res/layout/debug.xml
+++ b/res/layout/debug.xml
@@ -17,17 +17,12 @@
         android:layout_height="wrap_content"
         android:orientation="vertical" >
 
-        <CheckBox
-            android:id="@+id/debug_menu_ignore_etag"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/debug.ignore_etag" />
-
         <Button
             android:id="@+id/debug_menu_clear_db"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/debug.clear_db" />
+            android:text="@string/debug.clear_db" 
+	    android:visibility="gone"/>
 
         <Button
             android:id="@+id/debug_menu_fetch_all"

--- a/res/layout/debug.xml
+++ b/res/layout/debug.xml
@@ -15,21 +15,21 @@
     <LinearLayout
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical" >
+        android:orientation="vertical"
+        android:layout_marginTop="25dp" 
+        android:gravity="center">
 
         <Button
             android:id="@+id/debug_menu_clear_db"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/debug.clear_db" 
-	    android:visibility="gone"/>
-
+            android:text="@string/debug.clear_db"
+            android:visibility="gone"/>
         <Button
             android:id="@+id/debug_menu_fetch_all"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/debug.fetch_all_data" />
-
     </LinearLayout>
 
 </RelativeLayout>

--- a/src/com/futurice/festapp/DebugActivity.java
+++ b/src/com/futurice/festapp/DebugActivity.java
@@ -11,7 +11,7 @@ import android.widget.CompoundButton;
 
 public class DebugActivity extends Activity {
 
-	public final static boolean F_DEBUG = true;
+	public final static boolean F_DEBUG = false;
 	public volatile static boolean F_IGNORE_ETAG = false;
 
 	private View.OnClickListener clicklistener = new View.OnClickListener() {

--- a/src/com/futurice/festapp/DebugActivity.java
+++ b/src/com/futurice/festapp/DebugActivity.java
@@ -1,8 +1,11 @@
 package com.futurice.festapp;
 
+import com.futurice.festapp.service.FestAppService;
+
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
@@ -21,7 +24,11 @@ public class DebugActivity extends Activity {
 				//@TODO do stuff
 				break;
 			case R.id.debug_menu_fetch_all:
-				//@TODO do stuff
+				Log.d("ADASDASD", "starting intent force data load");
+				Intent i = new Intent(DebugActivity.this, FestAppService.class);
+				i.setAction("FORCE_DATA_LOAD");
+				startService(i);
+				
 				break;
 			}
 		}

--- a/src/com/futurice/festapp/DebugActivity.java
+++ b/src/com/futurice/festapp/DebugActivity.java
@@ -9,9 +9,6 @@ import android.view.View;
 
 public class DebugActivity extends Activity {
 
-	public final static boolean F_DEBUG = false;
-	public volatile static boolean F_IGNORE_ETAG = false;
-
 	private View.OnClickListener clicklistener = new View.OnClickListener() {
 
 		@Override

--- a/src/com/futurice/festapp/DebugActivity.java
+++ b/src/com/futurice/festapp/DebugActivity.java
@@ -5,7 +5,6 @@ import com.futurice.festapp.service.FestAppService;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
@@ -13,7 +12,7 @@ import android.widget.CompoundButton;
 public class DebugActivity extends Activity {
 
 	public final static boolean F_DEBUG = true;
-	public static boolean F_IGNORE_ETAG = false;
+	public volatile static boolean F_IGNORE_ETAG = false;
 
 	private View.OnClickListener clicklistener = new View.OnClickListener() {
 
@@ -24,9 +23,8 @@ public class DebugActivity extends Activity {
 				//@TODO do stuff
 				break;
 			case R.id.debug_menu_fetch_all:
-				Log.d("ADASDASD", "starting intent force data load");
 				Intent i = new Intent(DebugActivity.this, FestAppService.class);
-				i.setAction("FORCE_DATA_LOAD");
+				i.putExtra("com.futurice.festapp.service.FORCE", true);
 				startService(i);
 				
 				break;

--- a/src/com/futurice/festapp/DebugActivity.java
+++ b/src/com/futurice/festapp/DebugActivity.java
@@ -52,8 +52,9 @@ public class DebugActivity extends Activity {
 	}
 
 	private void createMenuItems() {
-		((CheckBox) findViewById(R.id.debug_menu_ignore_etag))
-				.setOnCheckedChangeListener(checkboxlistener);
+		CheckBox cb = (CheckBox) findViewById(R.id.debug_menu_ignore_etag);
+		cb.setOnCheckedChangeListener(checkboxlistener);
+		cb.setChecked(F_IGNORE_ETAG);
 		findViewById(R.id.debug_menu_clear_db)
 				.setOnClickListener(clicklistener);
 		findViewById(R.id.debug_menu_fetch_all).setOnClickListener(

--- a/src/com/futurice/festapp/DebugActivity.java
+++ b/src/com/futurice/festapp/DebugActivity.java
@@ -6,8 +6,6 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
-import android.widget.CheckBox;
-import android.widget.CompoundButton;
 
 public class DebugActivity extends Activity {
 
@@ -32,18 +30,6 @@ public class DebugActivity extends Activity {
 		}
 	};
 
-	private CompoundButton.OnCheckedChangeListener checkboxlistener = new CompoundButton.OnCheckedChangeListener() {
-
-		@Override
-		public void onCheckedChanged(CompoundButton v, boolean isChecked) {
-			switch (v.getId()) {
-			case R.id.debug_menu_ignore_etag:
-				F_IGNORE_ETAG = isChecked;
-				break;
-			}
-		}
-	};
-
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -52,9 +38,6 @@ public class DebugActivity extends Activity {
 	}
 
 	private void createMenuItems() {
-		CheckBox cb = (CheckBox) findViewById(R.id.debug_menu_ignore_etag);
-		cb.setOnCheckedChangeListener(checkboxlistener);
-		cb.setChecked(F_IGNORE_ETAG);
 		findViewById(R.id.debug_menu_clear_db)
 				.setOnClickListener(clicklistener);
 		findViewById(R.id.debug_menu_fetch_all).setOnClickListener(

--- a/src/com/futurice/festapp/FestAppMainActivity.java
+++ b/src/com/futurice/festapp/FestAppMainActivity.java
@@ -12,6 +12,7 @@ import com.futurice.festapp.dao.GigDAO;
 import com.futurice.festapp.dao.NewsDAO;
 import com.futurice.festapp.domain.NewsArticle;
 import com.futurice.festapp.service.FestAppService;
+import com.futurice.festapp.util.FestAppConstants;
 
 /**
  * Main activity.
@@ -62,7 +63,7 @@ public class FestAppMainActivity extends Activity {
 	}
 	
 	private void createMainMenuItems() {
-		if (DebugActivity.F_DEBUG){
+		if (FestAppConstants.F_DEBUG){
 			View v = findViewById(R.id.main_menu_debug);
 			v.setVisibility(View.VISIBLE);
 			v.setOnClickListener(clickListener);

--- a/src/com/futurice/festapp/service/FestAppService.java
+++ b/src/com/futurice/festapp/service/FestAppService.java
@@ -43,6 +43,14 @@ public class FestAppService extends Service{
 			Log.i(TAG, "Starting backend operations");
 			counter++;
 			try {
+				if (DebugActivity.F_IGNORE_ETAG){
+					updateGigs();
+					updateNewsArticles();
+					updateFoodAndDrinkPage();
+					updateTransportationPage();
+					updateServicesPageData();
+					updateFrequentlyAskedQuestionsPageData();
+				}
 				Date nowDate = new Date();
 				if (nowDate.before(GigDAO.getEndOfSunday())) {
 					alertGigs();
@@ -92,7 +100,6 @@ public class FestAppService extends Service{
 			public void run() {
 				try {
 					dataUpdateSem.acquire();
-					boolean eTagOrig = DebugActivity.F_IGNORE_ETAG;
 					if (force){
 						DebugActivity.F_IGNORE_ETAG = true;
 						Log.d(TAG, "Forced data reload");
@@ -100,11 +107,11 @@ public class FestAppService extends Service{
 					Log.d(TAG, "Running backend task");
 					backendTask.run();
 					Log.d(TAG, "Backend task finished");
-					DebugActivity.F_IGNORE_ETAG = eTagOrig;
 				} catch (InterruptedException e) {
 					e.printStackTrace();
 					return;
 				} finally{
+					DebugActivity.F_IGNORE_ETAG = false;
 					dataUpdateSem.release();
 				}
 			}

--- a/src/com/futurice/festapp/service/FestAppService.java
+++ b/src/com/futurice/festapp/service/FestAppService.java
@@ -101,10 +101,11 @@ public class FestAppService extends Service{
 					backendTask.run();
 					Log.d(TAG, "Backend task finished");
 					DebugActivity.F_IGNORE_ETAG = eTagOrig;
-					dataUpdateSem.release();
 				} catch (InterruptedException e) {
 					e.printStackTrace();
 					return;
+				} finally{
+					dataUpdateSem.release();
 				}
 			}
 		}.start();

--- a/src/com/futurice/festapp/service/FestAppService.java
+++ b/src/com/futurice/festapp/service/FestAppService.java
@@ -85,7 +85,7 @@ public class FestAppService extends Service{
 	public int onStartCommand(Intent intent, int flags, int startId) {
 		
 		final boolean force = intent.getExtras() != null && 
-				intent.getExtras().getBoolean("force");
+				intent.getBooleanExtra("com.futurice.festapp.service.FORCE", false);
 		
 		Log.d(TAG, "Running cron tasks");
 		new Thread() {

--- a/src/com/futurice/festapp/service/FestAppService.java
+++ b/src/com/futurice/festapp/service/FestAppService.java
@@ -42,13 +42,14 @@ public class FestAppService extends Service{
 			Log.i(TAG, "Starting backend operations");
 			counter++;
 			try {
-				if (FestAppConstants.F_IGNORE_ETAG){
+				if (FestAppConstants.F_FORCE_DATA_FETCH){
 					updateGigs();
 					updateNewsArticles();
 					updateFoodAndDrinkPage();
 					updateTransportationPage();
 					updateServicesPageData();
 					updateFrequentlyAskedQuestionsPageData();
+					return;
 				}
 				Date nowDate = new Date();
 				if (nowDate.before(GigDAO.getEndOfSunday())) {
@@ -100,7 +101,7 @@ public class FestAppService extends Service{
 				try {
 					dataUpdateSem.acquire();
 					if (force){
-						FestAppConstants.F_IGNORE_ETAG = true;
+						FestAppConstants.F_FORCE_DATA_FETCH = true;
 						Log.d(TAG, "Forced data reload");
 					}
 					Log.d(TAG, "Running backend task");
@@ -110,7 +111,7 @@ public class FestAppService extends Service{
 					e.printStackTrace();
 					return;
 				} finally{
-					FestAppConstants.F_IGNORE_ETAG = false;
+					FestAppConstants.F_FORCE_DATA_FETCH = false;
 					dataUpdateSem.release();
 				}
 			}

--- a/src/com/futurice/festapp/service/FestAppService.java
+++ b/src/com/futurice/festapp/service/FestAppService.java
@@ -14,7 +14,6 @@ import android.content.Intent;
 import android.os.IBinder;
 import android.util.Log;
 
-import com.futurice.festapp.DebugActivity;
 import com.futurice.festapp.FestAppMainActivity;
 import com.futurice.festapp.R;
 import com.futurice.festapp.dao.ConfigDAO;
@@ -43,7 +42,7 @@ public class FestAppService extends Service{
 			Log.i(TAG, "Starting backend operations");
 			counter++;
 			try {
-				if (DebugActivity.F_IGNORE_ETAG){
+				if (FestAppConstants.F_IGNORE_ETAG){
 					updateGigs();
 					updateNewsArticles();
 					updateFoodAndDrinkPage();
@@ -101,7 +100,7 @@ public class FestAppService extends Service{
 				try {
 					dataUpdateSem.acquire();
 					if (force){
-						DebugActivity.F_IGNORE_ETAG = true;
+						FestAppConstants.F_IGNORE_ETAG = true;
 						Log.d(TAG, "Forced data reload");
 					}
 					Log.d(TAG, "Running backend task");
@@ -111,7 +110,7 @@ public class FestAppService extends Service{
 					e.printStackTrace();
 					return;
 				} finally{
-					DebugActivity.F_IGNORE_ETAG = false;
+					FestAppConstants.F_IGNORE_ETAG = false;
 					dataUpdateSem.release();
 				}
 			}

--- a/src/com/futurice/festapp/service/ServiceBroadcastReceiver.java
+++ b/src/com/futurice/festapp/service/ServiceBroadcastReceiver.java
@@ -9,10 +9,8 @@ public class ServiceBroadcastReceiver extends BroadcastReceiver {
 	
     @Override
     public void onReceive(Context context, Intent intent ) {
-    	Log.d("CHECK", "receive intent, action = " + intent.getAction());
-        
-    	if (intent.getAction().equals("FORCE_DATA_LOAD")){
-    		Log.d("CHECK", "force data reload found");
+    	if (intent.getExtras() != null && 
+    			intent.getBooleanExtra("com.futurice.festapp.service.FORCE", false)){
             Intent myIntent = new Intent( context, FestAppService.class );
             myIntent.putExtra("force", true);
             context.startService( myIntent );

--- a/src/com/futurice/festapp/service/ServiceBroadcastReceiver.java
+++ b/src/com/futurice/festapp/service/ServiceBroadcastReceiver.java
@@ -8,15 +8,7 @@ public class ServiceBroadcastReceiver extends BroadcastReceiver {
 	
     @Override
     public void onReceive(Context context, Intent intent ) {
-    	if (intent.getExtras() != null && 
-    			intent.getBooleanExtra("com.futurice.festapp.service.FORCE", false)){
-            Intent myIntent = new Intent( context, FestAppService.class );
-            myIntent.putExtra("force", true);
-            context.startService( myIntent );
-    	}
-    	else{
-            Intent myIntent = new Intent( context, FestAppService.class );
-            context.startService( myIntent );
-    	}
+        Intent myIntent = new Intent( context, FestAppService.class );
+        context.startService( myIntent );
     }
 }

--- a/src/com/futurice/festapp/service/ServiceBroadcastReceiver.java
+++ b/src/com/futurice/festapp/service/ServiceBroadcastReceiver.java
@@ -3,7 +3,6 @@ package com.futurice.festapp.service;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.util.Log;
 
 public class ServiceBroadcastReceiver extends BroadcastReceiver {
 	

--- a/src/com/futurice/festapp/service/ServiceBroadcastReceiver.java
+++ b/src/com/futurice/festapp/service/ServiceBroadcastReceiver.java
@@ -3,12 +3,23 @@ package com.futurice.festapp.service;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.util.Log;
 
 public class ServiceBroadcastReceiver extends BroadcastReceiver {
-	 
+	
     @Override
     public void onReceive(Context context, Intent intent ) {
-        Intent myIntent = new Intent( context, FestAppService.class );
-        context.startService( myIntent );
+    	Log.d("CHECK", "receive intent, action = " + intent.getAction());
+        
+    	if (intent.getAction().equals("FORCE_DATA_LOAD")){
+    		Log.d("CHECK", "force data reload found");
+            Intent myIntent = new Intent( context, FestAppService.class );
+            myIntent.putExtra("force", true);
+            context.startService( myIntent );
+    	}
+    	else{
+            Intent myIntent = new Intent( context, FestAppService.class );
+            context.startService( myIntent );
+    	}
     }
 }

--- a/src/com/futurice/festapp/util/FestAppConstants.java
+++ b/src/com/futurice/festapp/util/FestAppConstants.java
@@ -36,5 +36,5 @@ public class FestAppConstants {
 		
 	// DEBUG variables
 	public final static boolean F_DEBUG = false;
-	public volatile static boolean F_IGNORE_ETAG = false;
+	public volatile static boolean F_FORCE_DATA_FETCH = false;
 }

--- a/src/com/futurice/festapp/util/FestAppConstants.java
+++ b/src/com/futurice/festapp/util/FestAppConstants.java
@@ -34,4 +34,7 @@ public class FestAppConstants {
 	public static final String LAST_MODIFIED_GENERAL_INFO = null;
 	public static final String LAST_MODIFIED_FAQ = null;
 		
+	// DEBUG variables
+	public final static boolean F_DEBUG = false;
+	public volatile static boolean F_IGNORE_ETAG = false;
 }

--- a/src/com/futurice/festapp/util/HTTPUtil.java
+++ b/src/com/futurice/festapp/util/HTTPUtil.java
@@ -122,7 +122,7 @@ public class HTTPUtil {
 	}
 
 	public static boolean isContentUpdated(String urlString, String previousEtag) throws Exception {
-		if (FestAppConstants.F_IGNORE_ETAG){
+		if (FestAppConstants.F_FORCE_DATA_FETCH){
 			Log.d(TAG, "ETAG ignored!");
 			return true;
 		}

--- a/src/com/futurice/festapp/util/HTTPUtil.java
+++ b/src/com/futurice/festapp/util/HTTPUtil.java
@@ -130,6 +130,7 @@ public class HTTPUtil {
 	public static boolean isContentUpdated(String urlString, String previousEtag) throws Exception {
 
 		if (DebugActivity.F_IGNORE_ETAG){
+			Log.d(TAG, "ETAG ignored!");
 			return true;
 		}
 

--- a/src/com/futurice/festapp/util/HTTPUtil.java
+++ b/src/com/futurice/festapp/util/HTTPUtil.java
@@ -48,6 +48,7 @@ import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.HTTP;
 import org.apache.http.protocol.HttpContext;
 
+import com.futurice.festapp.DebugActivity;
 import com.futurice.festapp.domain.to.HTTPBackendResponse;
 
 import android.util.Log;
@@ -127,6 +128,11 @@ public class HTTPUtil {
 	}
 
 	public static boolean isContentUpdated(String urlString, String previousEtag) throws Exception {
+
+		if (DebugActivity.F_IGNORE_ETAG){
+			return true;
+		}
+
 		if (previousEtag == null || previousEtag.length() == 0) {
 			return true;
 		}

--- a/src/com/futurice/festapp/util/HTTPUtil.java
+++ b/src/com/futurice/festapp/util/HTTPUtil.java
@@ -46,7 +46,6 @@ import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.HTTP;
 import org.apache.http.protocol.HttpContext;
 
-import com.futurice.festapp.DebugActivity;
 import com.futurice.festapp.domain.to.HTTPBackendResponse;
 
 import android.util.Log;
@@ -123,7 +122,7 @@ public class HTTPUtil {
 	}
 
 	public static boolean isContentUpdated(String urlString, String previousEtag) throws Exception {
-		if (DebugActivity.F_IGNORE_ETAG){
+		if (FestAppConstants.F_IGNORE_ETAG){
 			Log.d(TAG, "ETAG ignored!");
 			return true;
 		}

--- a/src/com/futurice/festapp/util/HTTPUtil.java
+++ b/src/com/futurice/festapp/util/HTTPUtil.java
@@ -128,7 +128,6 @@ public class HTTPUtil {
 	}
 
 	public static boolean isContentUpdated(String urlString, String previousEtag) throws Exception {
-
 		if (DebugActivity.F_IGNORE_ETAG){
 			Log.d(TAG, "ETAG ignored!");
 			return true;


### PR DESCRIPTION
A checkbox in Debug-menu for ignoring ETags when deciding whether to get new data from backend and a button for forcing the retrieval of data.

Due to backend changes, no testing with real backend data was possible.
