### PR TITLE
#22 fixed

### DIFF
--- a/src/com/futurice/festapp/MapActivity.java
+++ b/src/com/futurice/festapp/MapActivity.java
@@ -1,6 +1,7 @@
 package com.futurice.festapp;
 
 import java.util.Timer;
+
 import com.futurice.festapp.dao.GigDAO;
 import com.futurice.festapp.domain.to.StageType;
 import com.futurice.festapp.ui.map.MapAnimation;
@@ -27,6 +28,7 @@ import android.view.View.OnClickListener;
 import android.view.View.OnTouchListener;
 import android.widget.ImageButton;
 import android.widget.Toast;
+
 import com.futurice.festapp.R;
 
 /**
@@ -174,7 +176,6 @@ public class MapActivity extends Activity {
 			}
 
 			if ((event.getAction() == MotionEvent.ACTION_MOVE)) {
-
 				moveHistorySize++;
 				lastTwoXMoves[1] = lastTwoXMoves[0];
 				lastTwoXMoves[0] = event.getX();
@@ -186,6 +187,19 @@ public class MapActivity extends Activity {
 					current_centerY += (int) ((lastTwoYMoves[1] - lastTwoYMoves[0]) * (mapSizeY / current_scale) / mapImageView.getHeight());
 
 					updateDisplay();
+					
+					if (event.getEventTime() != downTimer) {
+						float speedX = (lastTwoXMoves[1] - lastTwoXMoves[0]) * (mapSizeX / current_scale) / mapImageView.getWidth();
+						float speedY = (lastTwoYMoves[1] - lastTwoYMoves[0]) * (mapSizeY / current_scale) / mapImageView.getHeight();
+
+						speedX /= event.getEventTime() - downTimer;
+						speedY /= event.getEventTime() - downTimer;
+
+						speedX *= 30;
+						speedY *= 30;
+
+						animation.setInfo(speedX, speedY, current_centerX, current_centerY);
+					}
 				}
 			} else if (event.getAction() == MotionEvent.ACTION_DOWN) {
 				animation.stopProcess();
@@ -193,21 +207,7 @@ public class MapActivity extends Activity {
 				lastTwoYMoves[0] = event.getY();
 				downTimer = event.getEventTime();
 				moveHistorySize = 1;
-			} else if ((event.getAction() == MotionEvent.ACTION_UP) && (moveHistorySize >= 1)) {
-
-				if (event.getEventTime() != downTimer) {
-					float speedX = (lastTwoXMoves[1] - lastTwoXMoves[0]) * (mapSizeX / current_scale) / mapImageView.getWidth();
-					float speedY = (lastTwoYMoves[1] - lastTwoYMoves[0]) * (mapSizeY / current_scale) / mapImageView.getHeight();
-
-					speedX /= event.getEventTime() - downTimer;
-					speedY /= event.getEventTime() - downTimer;
-
-					speedX *= 30;
-					speedY *= 30;
-
-					animation.setInfo(speedX, speedY, current_centerX, current_centerY);
-				}
-			}
+			} 
 
 			return true;
 		}


### PR DESCRIPTION
The bug was caused because the parameters for the animation (set by animation.info() ) were not correct, as they were only updated when the ACTION_UP touch event was dispatched. In order to solve this, the parameters are now updated whenever the ACTION_MOVE touch event is performed. The original issue can be very well noticed if the user moves the finger in order to span the map and without lifting it, touches the zoom in or zoom out button.
