### PR TITLE
Duplicate fetch

### DIFF
--- a/src/com/futurice/festapp/FestAppMainActivity.java
+++ b/src/com/futurice/festapp/FestAppMainActivity.java
@@ -65,7 +65,7 @@ public class FestAppMainActivity extends Activity {
 			AlarmManager alarmManager = (AlarmManager)getSystemService(ALARM_SERVICE);
 			long wait = FestAppConstants.SERVICE_INITIAL_WAIT_TIME;
 			long interval = FestAppConstants.SERVICE_FREQUENCY;
-			alarmManager.setInexactRepeating(AlarmManager.RTC_WAKEUP, wait, interval, alarmIntent);;
+			alarmManager.setInexactRepeating(AlarmManager.RTC_WAKEUP, wait, interval, alarmIntent);
 			Log.i("Init", "Creating service");
 		}
 		createMainMenuItems();

--- a/src/com/futurice/festapp/FestAppMainActivity.java
+++ b/src/com/futurice/festapp/FestAppMainActivity.java
@@ -3,15 +3,17 @@ package com.futurice.festapp;
 import java.util.Date;
 
 import android.app.Activity;
+import android.app.AlarmManager;
+import android.app.PendingIntent;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 
 import com.futurice.festapp.dao.ConfigDAO;
 import com.futurice.festapp.dao.GigDAO;
 import com.futurice.festapp.dao.NewsDAO;
 import com.futurice.festapp.domain.NewsArticle;
-import com.futurice.festapp.service.FestAppService;
 import com.futurice.festapp.util.FestAppConstants;
 
 /**
@@ -20,6 +22,8 @@ import com.futurice.festapp.util.FestAppConstants;
  * @author Pyry-Samuli Lahti / Futurice
  */
 public class FestAppMainActivity extends Activity {
+	
+	private PendingIntent alarmIntent;
 	
 	private View.OnClickListener clickListener = new View.OnClickListener() {
 		@Override
@@ -56,7 +60,13 @@ public class FestAppMainActivity extends Activity {
 		setContentView(R.layout.main);
 		Date dateNow = new Date();
 		if (dateNow.before(GigDAO.getEndOfSunday())) {
-			startService(new Intent(this, FestAppService.class));
+			Intent i = new Intent("CHECK_ALARMS");
+			alarmIntent = PendingIntent.getBroadcast(this, 12345, i, PendingIntent.FLAG_CANCEL_CURRENT);
+			AlarmManager alarmManager = (AlarmManager)getSystemService(ALARM_SERVICE);
+			long wait = FestAppConstants.SERVICE_INITIAL_WAIT_TIME;
+			long interval = FestAppConstants.SERVICE_FREQUENCY;
+			alarmManager.setInexactRepeating(AlarmManager.RTC_WAKEUP, wait, interval, alarmIntent);;
+			Log.i("Init", "Creating service");
 		}
 		createMainMenuItems();
 		handleNotificationEvents();
@@ -98,6 +108,12 @@ public class FestAppMainActivity extends Activity {
 		}
 	}
 
+	@Override
+	protected void onDestroy() {
+		AlarmManager alarmManager = (AlarmManager)getSystemService(ALARM_SERVICE);
+		alarmManager.cancel(alarmIntent);
+		super.onDestroy();
+	}
 	
 	/*
 	@Override

--- a/src/com/futurice/festapp/service/FestAppService.java
+++ b/src/com/futurice/festapp/service/FestAppService.java
@@ -34,7 +34,6 @@ public class FestAppService extends Service{
 
 	private static final String TAG = FestAppService.class.getSimpleName();
 	private int counter = -1;
-	private PendingIntent alarmIntent;
 	private Semaphore dataUpdateSem = new Semaphore(1);
 	private TimerTask backendTask = new TimerTask() {
 		@Override
@@ -263,21 +262,12 @@ public class FestAppService extends Service{
 	@Override
 	public void onCreate() {
 		super.onCreate();
-		Intent intent = new Intent("CHECK_ALARMS");
-		alarmIntent = PendingIntent.getBroadcast(this, 12345, intent, PendingIntent.FLAG_CANCEL_CURRENT);
-		AlarmManager alarmManager = (AlarmManager)getSystemService(ALARM_SERVICE);
-		long wait = FestAppConstants.SERVICE_INITIAL_WAIT_TIME;
-		long interval = FestAppConstants.SERVICE_FREQUENCY;
-		alarmManager.setInexactRepeating(AlarmManager.RTC_WAKEUP, wait, interval, alarmIntent);;
-		Log.i(TAG, "Creating service");
 	}
 	
 	@Override
 	public void onDestroy() {
 		super.onDestroy();
 		Log.i(TAG, "Destroying service");
-		AlarmManager alarmManager = (AlarmManager)getSystemService(ALARM_SERVICE);
-		alarmManager.cancel(alarmIntent);
 	}
 
 	@Override

--- a/src/com/futurice/festapp/service/FestAppService.java
+++ b/src/com/futurice/festapp/service/FestAppService.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.TimerTask;
 import java.util.concurrent.Semaphore;
 
-import android.app.AlarmManager;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -269,7 +268,6 @@ public class FestAppService extends Service{
 	@Override
 	public void onDestroy() {
 		super.onDestroy();
-		Log.i(TAG, "Destroying service");
 	}
 
 	@Override


### PR DESCRIPTION
Fixes issue #77.

Moved AlarmManager logic from FestAppService to FestAppMainActivity, as the service duplication happened because of generated Services scheduling new Services.

Also scheduling the repeating services in main activity is much easier to understand.
