### PR TITLE
Allow overriding API URLs (Issue #13)

### DIFF
--- a/src/com/futurice/festapp/InfoSubPageActivity.java
+++ b/src/com/futurice/festapp/InfoSubPageActivity.java
@@ -2,13 +2,14 @@ package com.futurice.festapp;
 
 import java.util.HashMap;
 
-import com.futurice.festapp.util.FestAppConstants;
+import com.futurice.festapp.util.URLUtil;
 
 import android.app.Activity;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.webkit.WebView;
 import android.widget.TextView;
+
 import com.futurice.festapp.R;
 
 /**
@@ -35,7 +36,8 @@ public class InfoSubPageActivity extends Activity {
 
 		WebView contentView = (WebView) findViewById(R.id.infoPageWebView);
 		contentView.setBackgroundColor(Color.TRANSPARENT);
-		contentView.loadDataWithBaseURL(FestAppConstants.WEBSITE_BASE_URL, pageContent, "text/html", "utf-8", null);
+		String baseUrl = URLUtil.getInstance(getApplicationContext()).getUrl(URLUtil.WEBSITE_BASE_URL);
+		contentView.loadDataWithBaseURL(baseUrl, pageContent, "text/html", "utf-8", null);
 		HashMap<String, String> titleMap = new HashMap<String, String>();
 		titleMap.put("title", pageTitle);
 	}

--- a/src/com/futurice/festapp/NewsContentActivity.java
+++ b/src/com/futurice/festapp/NewsContentActivity.java
@@ -2,13 +2,14 @@ package com.futurice.festapp;
 
 import java.util.HashMap;
 
-import com.futurice.festapp.util.FestAppConstants;
+import com.futurice.festapp.util.URLUtil;
 
 import android.app.Activity;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.webkit.WebView;
 import android.widget.TextView;
+
 import com.futurice.festapp.R;
 
 /**
@@ -39,7 +40,8 @@ public class NewsContentActivity extends Activity {
 			titleView.setText((String) extras.get("news.title"));
 			dateView.setText((String) extras.get("news.date"));
 			contentView.setBackgroundColor(Color.TRANSPARENT);
-			contentView.loadDataWithBaseURL(FestAppConstants.WEBSITE_BASE_URL, (String) extras.get("news.content"), "text/html", "utf-8", null);
+			String baseUrl = URLUtil.getInstance(getApplicationContext()).getUrl(URLUtil.WEBSITE_BASE_URL);
+			contentView.loadDataWithBaseURL(baseUrl, (String) extras.get("news.content"), "text/html", "utf-8", null);
 		}
 		HashMap<String, String> titleMap = new HashMap<String, String>();
 		titleMap.put("title", titleView.getText().toString());

--- a/src/com/futurice/festapp/dao/ConfigDAO.java
+++ b/src/com/futurice/festapp/dao/ConfigDAO.java
@@ -18,9 +18,9 @@ import com.futurice.festapp.R;
 import com.futurice.festapp.domain.to.HTTPBackendResponse;
 import com.futurice.festapp.domain.to.MapLayerOptions;
 import com.futurice.festapp.domain.to.SelectableOption;
-import com.futurice.festapp.util.FestAppConstants;
 import com.futurice.festapp.util.HTTPUtil;
 import com.futurice.festapp.util.JSONUtil;
+import com.futurice.festapp.util.URLUtil;
 
 /**
  * Data-access operations for Configuration options.
@@ -226,7 +226,8 @@ public class ConfigDAO {
 
 	public static void updateFoodAndDrinkPageOverHttp(Context context) {
 		HTTPUtil httpUtil = new HTTPUtil();
-		HTTPBackendResponse response = httpUtil.performGet(FestAppConstants.FOOD_AND_DRINK_HTML_URL);
+		HTTPBackendResponse response =
+				httpUtil.performGet(URLUtil.getInstance(context).getUrl(URLUtil.FOOD_AND_DRINK_HTML_URL));
 		if (!response.isValid() || response.getContent() == null) {
 			return;
 		}
@@ -266,7 +267,8 @@ public class ConfigDAO {
 
 	public static void updateTransportationPageOverHttp(Context context) {
 		HTTPUtil httpUtil = new HTTPUtil();
-		HTTPBackendResponse response = httpUtil.performGet(FestAppConstants.TRANSPORTATION_HTML_URL);
+		HTTPBackendResponse response =
+				httpUtil.performGet(URLUtil.getInstance(context).getUrl(URLUtil.TRANSPORTATION_HTML_URL));
 		if (!response.isValid() || response.getContent() == null) {
 			return;
 		}
@@ -276,7 +278,8 @@ public class ConfigDAO {
 	
 	public static void updateServicePagesOverHttp(Context context) {
 		HTTPUtil httpUtil = new HTTPUtil();
-		HTTPBackendResponse response = httpUtil.performGet(FestAppConstants.SERVICES_JSON_URL);
+		HTTPBackendResponse response =
+				httpUtil.performGet(URLUtil.getInstance(context).getUrl(URLUtil.SERVICES_JSON_URL));
 		if (!response.isValid() || response.getContent() == null) {
 			return;
 		}
@@ -290,7 +293,8 @@ public class ConfigDAO {
 	
 	public static void updateFrequentlyAskedQuestionsPagesOverHttp(Context context) {
 		HTTPUtil httpUtil = new HTTPUtil();
-		HTTPBackendResponse response = httpUtil.performGet(FestAppConstants.FREQUENTLY_ASKED_QUESTIONS_JSON_URL);
+		HTTPBackendResponse response =
+				httpUtil.performGet(URLUtil.getInstance(context).getUrl(URLUtil.FREQUENTLY_ASKED_QUESTIONS_JSON_URL));
 		if (!response.isValid() || response.getContent() == null) {
 			return;
 		}

--- a/src/com/futurice/festapp/dao/GigDAO.java
+++ b/src/com/futurice/festapp/dao/GigDAO.java
@@ -25,14 +25,15 @@ import com.futurice.festapp.domain.to.StageType;
 import com.futurice.festapp.util.GigArtistNameComparator;
 import com.futurice.festapp.util.HTTPUtil;
 import com.futurice.festapp.util.JSONUtil;
-import com.futurice.festapp.util.FestAppConstants;
 import com.futurice.festapp.util.StringUtil;
+import com.futurice.festapp.util.URLUtil;
 
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.util.Log;
+
 import com.futurice.festapp.R;
 
 /**
@@ -217,7 +218,8 @@ public class GigDAO {
 	
 	public static void updateGigsOverHttp(Context context) throws Exception {
 		HTTPUtil httpUtil = new HTTPUtil();
-		HTTPBackendResponse response = httpUtil.performGet(FestAppConstants.GIGS_JSON_URL);
+		HTTPBackendResponse response =
+				httpUtil.performGet(URLUtil.getInstance(context).getUrl(URLUtil.GIGS_JSON_URL));
 		if (!response.isValid() || response.getContent() == null) {
 			return;
 		}

--- a/src/com/futurice/festapp/dao/NewsDAO.java
+++ b/src/com/futurice/festapp/dao/NewsDAO.java
@@ -13,7 +13,7 @@ import com.futurice.festapp.domain.NewsArticle;
 import com.futurice.festapp.domain.to.HTTPBackendResponse;
 import com.futurice.festapp.util.HTTPUtil;
 import com.futurice.festapp.util.JSONUtil;
-import com.futurice.festapp.util.FestAppConstants;
+import com.futurice.festapp.util.URLUtil;
 
 import android.content.ContentValues;
 import android.content.Context;
@@ -77,7 +77,8 @@ public class NewsDAO {
 
 	public static List<NewsArticle> updateNewsOverHttp(Context context) {
 		HTTPUtil httpUtil = new HTTPUtil();
-		HTTPBackendResponse response = httpUtil.performGet(FestAppConstants.NEWS_JSON_URL);
+		HTTPBackendResponse response =
+				httpUtil.performGet(URLUtil.getInstance(context).getUrl(URLUtil.NEWS_JSON_URL));
 		if (!response.isValid() || response.getContent() == null) {
 			return null;
 		}

--- a/src/com/futurice/festapp/service/FestAppService.java
+++ b/src/com/futurice/festapp/service/FestAppService.java
@@ -24,6 +24,7 @@ import com.futurice.festapp.domain.NewsArticle;
 import com.futurice.festapp.util.CalendarUtil;
 import com.futurice.festapp.util.FestAppConstants;
 import com.futurice.festapp.util.HTTPUtil;
+import com.futurice.festapp.util.URLUtil;
 
 /**
  * Application background services.
@@ -161,7 +162,8 @@ public class FestAppService extends Service{
 
 	private void updateNewsArticles() {
 		try {
-			if (HTTPUtil.isContentUpdated(FestAppConstants.NEWS_JSON_URL,
+			if (HTTPUtil.isContentUpdated(
+					URLUtil.getInstance(getApplicationContext()).getUrl(URLUtil.NEWS_JSON_URL),
 					ConfigDAO.getEtagForNews(getBaseContext()))) {
 				List<NewsArticle> newArticles = NewsDAO
 						.updateNewsOverHttp(getBaseContext());
@@ -185,7 +187,8 @@ public class FestAppService extends Service{
 
 	private void updateServicesPageData() {
 		try {
-			if (HTTPUtil.isContentUpdated(FestAppConstants.SERVICES_JSON_URL,
+			if (HTTPUtil.isContentUpdated(
+					URLUtil.getInstance(getApplicationContext()).getUrl(URLUtil.SERVICES_JSON_URL),
 					ConfigDAO.getEtagForServices(getBaseContext()))) {
 				ConfigDAO.updateServicePagesOverHttp(getBaseContext());
 				Log.i(TAG, "Successfully updated data for Services.");
@@ -201,7 +204,7 @@ public class FestAppService extends Service{
 		try {
 			if (HTTPUtil
 					.isContentUpdated(
-							FestAppConstants.FREQUENTLY_ASKED_QUESTIONS_JSON_URL,
+							URLUtil.getInstance(getApplicationContext()).getUrl(URLUtil.FREQUENTLY_ASKED_QUESTIONS_JSON_URL),
 							ConfigDAO
 									.getEtagForFrequentlyAskedQuestions(getBaseContext()))) {
 				ConfigDAO
@@ -219,7 +222,7 @@ public class FestAppService extends Service{
 	private void updateFoodAndDrinkPage() {
 		try {
 			if (HTTPUtil.isContentUpdated(
-					FestAppConstants.FOOD_AND_DRINK_HTML_URL,
+					URLUtil.getInstance(getApplicationContext()).getUrl(URLUtil.FOOD_AND_DRINK_HTML_URL),
 					ConfigDAO.getEtagForFoodAndDrink(getBaseContext()))) {
 				ConfigDAO.updateFoodAndDrinkPageOverHttp(getBaseContext());
 				Log.i(TAG, "Successfully updated data for FoodAndDrink.");
@@ -234,7 +237,7 @@ public class FestAppService extends Service{
 	private void updateTransportationPage() {
 		try {
 			if (HTTPUtil.isContentUpdated(
-					FestAppConstants.TRANSPORTATION_HTML_URL,
+					URLUtil.getInstance(getApplicationContext()).getUrl(URLUtil.TRANSPORTATION_HTML_URL),
 					ConfigDAO.getEtagForTransportation(getBaseContext()))) {
 				ConfigDAO.updateTransportationPageOverHttp(getBaseContext());
 				Log.i(TAG, "Successfully updated data for Transportation.");
@@ -248,7 +251,7 @@ public class FestAppService extends Service{
 
 	private void updateGigs() {
 		try {
-			if (HTTPUtil.isContentUpdated(FestAppConstants.GIGS_JSON_URL,
+			if (HTTPUtil.isContentUpdated(URLUtil.getInstance(getApplicationContext()).getUrl(URLUtil.GIGS_JSON_URL),
 					ConfigDAO.getEtagForGigs(getBaseContext()))) {
 				GigDAO.updateGigsOverHttp(getBaseContext());
 				Log.i(TAG, "Successfully updated Gigs.");

--- a/src/com/futurice/festapp/util/FestAppConstants.java
+++ b/src/com/futurice/festapp/util/FestAppConstants.java
@@ -2,17 +2,6 @@ package com.futurice.festapp.util;
 
 public class FestAppConstants {
 	
-	public static final String WEBSITE_BASE_URL = "http://festapp-server.herokuapp.com/";
-	
-	public static final String BASE_URL = "http://festapp-server.herokuapp.com";
-	public static final String NEWS_JSON_URL = "/api/news";
-	public static final String GIGS_JSON_URL = "/api/artists";
-	public static final String TRANSPORTATION_HTML_URL = "/api/arrival";
-	public static final String SERVICES_JSON_URL = "/api/services";
-	
-	public static final String FREQUENTLY_ASKED_QUESTIONS_JSON_URL = "/api/info";
-	public static final String FOOD_AND_DRINK_HTML_URL =  "/api/program";
-	
 	public static final String DRAWABLE_ARTIST_LOGO_PREFIX = "artist_";
 	public static final String DRAWABLE_GUITAR_STRING_PREFIX = "guitar_string_";
 	

--- a/src/com/futurice/festapp/util/URLUtil.java
+++ b/src/com/futurice/festapp/util/URLUtil.java
@@ -1,0 +1,98 @@
+package com.futurice.festapp.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+
+import android.content.Context;
+import android.content.res.AssetManager;
+import android.util.JsonReader;
+import android.util.Log;
+
+public class URLUtil {
+
+	private static URLUtil instance = null;
+
+	public static final int WEBSITE_BASE_URL = 0;
+	public static final int NEWS_JSON_URL = 1;
+	public static final int GIGS_JSON_URL = 2;
+	public static final int TRANSPORTATION_HTML_URL = 3;
+	public static final int SERVICES_JSON_URL = 4;
+	public static final int FREQUENTLY_ASKED_QUESTIONS_JSON_URL = 5;
+	public static final int FOOD_AND_DRINK_HTML_URL = 6;
+	
+	private static final String URL_OVERRIDE_PATH = "url_overrides.json";
+
+	private static final String[] urlNames = { "website_base_url",
+			"news_json_url", "gigs_json_url", "transportation_html_url",
+			"services_json_url", "frequently_asked_questions_json_url",
+			"food_and_drink_html_url", };
+
+	private String[] urls = { "http://festapp-server.herokuapp.com/",
+			"/api/news", "/api/artists", "/api/arrival", "/api/services",
+			"/api/info", "/api/program", };
+	
+	private static void readUrlOverride(JsonReader reader, HashMap<String, String> results) throws IOException {
+		String name = reader.nextName();
+		String value = reader.nextString();
+		
+		results.put(name, value);
+	}
+	
+	private static HashMap<String, String> getUrlOverrides(InputStream stream) throws IOException {
+        HashMap<String, String> overrides = new HashMap<String, String>();
+        JsonReader reader = new JsonReader(new InputStreamReader(stream));
+        
+        reader.beginObject();
+        
+        while (reader.hasNext()) {
+        	readUrlOverride(reader, overrides);
+        }
+        
+        reader.endObject();
+        
+        return overrides;
+	}
+
+	private URLUtil(Context context) {
+		AssetManager assets = context.getAssets();
+		InputStream stream = null;
+		
+		try {
+			stream = assets.open(URL_OVERRIDE_PATH);
+		} catch (IOException ex) {
+			// Nothing to do here, just use the default URLs.
+			Log.v("URLUtil", "URL override file not found, using defaults.");
+			return;
+		}
+		
+		try {
+			HashMap<String, String> overrides = getUrlOverrides(stream);
+			
+			for (int urlIdx = 0; urlIdx < urlNames.length; urlIdx++) {
+				String urlName = urlNames[urlIdx];
+
+				if (overrides.containsKey(urlName)) {
+					urls[urlIdx] = overrides.get(urlName);
+				}
+			}
+
+			stream.close();
+		} catch (IOException e) {
+			// Ignored.
+		}
+	}
+	
+	public static URLUtil getInstance(Context context) {
+		if (instance == null) {
+			instance = new URLUtil(context);
+		}
+
+		return instance;
+	}
+
+	public String getUrl(int urlIndex) {
+		return urls[urlIndex];
+	}
+}

--- a/src/com/futurice/festapp/util/URLUtil.java
+++ b/src/com/futurice/festapp/util/URLUtil.java
@@ -21,7 +21,7 @@ public class URLUtil {
 	public static final int SERVICES_JSON_URL = 4;
 	public static final int FREQUENTLY_ASKED_QUESTIONS_JSON_URL = 5;
 	public static final int FOOD_AND_DRINK_HTML_URL = 6;
-	
+
 	private static final String URL_OVERRIDE_PATH = "url_overrides.json";
 
 	private static final String[] urlNames = { "website_base_url",
@@ -32,33 +32,35 @@ public class URLUtil {
 	private String[] urls = { "http://festapp-server.herokuapp.com/",
 			"/api/news", "/api/artists", "/api/arrival", "/api/services",
 			"/api/info", "/api/program", };
-	
-	private static void readUrlOverride(JsonReader reader, HashMap<String, String> results) throws IOException {
+
+	private static void readUrlOverride(JsonReader reader,
+			HashMap<String, String> results) throws IOException {
 		String name = reader.nextName();
 		String value = reader.nextString();
-		
+
 		results.put(name, value);
 	}
-	
-	private static HashMap<String, String> getUrlOverrides(InputStream stream) throws IOException {
-        HashMap<String, String> overrides = new HashMap<String, String>();
-        JsonReader reader = new JsonReader(new InputStreamReader(stream));
-        
-        reader.beginObject();
-        
-        while (reader.hasNext()) {
-        	readUrlOverride(reader, overrides);
-        }
-        
-        reader.endObject();
-        
-        return overrides;
+
+	private static HashMap<String, String> getUrlOverrides(InputStream stream)
+			throws IOException {
+		HashMap<String, String> overrides = new HashMap<String, String>();
+		JsonReader reader = new JsonReader(new InputStreamReader(stream));
+
+		reader.beginObject();
+
+		while (reader.hasNext()) {
+			readUrlOverride(reader, overrides);
+		}
+
+		reader.endObject();
+
+		return overrides;
 	}
 
 	private URLUtil(Context context) {
 		AssetManager assets = context.getAssets();
 		InputStream stream = null;
-		
+
 		try {
 			stream = assets.open(URL_OVERRIDE_PATH);
 		} catch (IOException ex) {
@@ -66,10 +68,10 @@ public class URLUtil {
 			Log.v("URLUtil", "URL override file not found, using defaults.");
 			return;
 		}
-		
+
 		try {
 			HashMap<String, String> overrides = getUrlOverrides(stream);
-			
+
 			for (int urlIdx = 0; urlIdx < urlNames.length; urlIdx++) {
 				String urlName = urlNames[urlIdx];
 
@@ -83,7 +85,7 @@ public class URLUtil {
 			// Ignored.
 		}
 	}
-	
+
 	public static URLUtil getInstance(Context context) {
 		if (instance == null) {
 			instance = new URLUtil(context);


### PR DESCRIPTION
API URLs are loaded from assets/url_overrides.json. If this file is not found or has overrides only for specific URLs defaults will be used where appropiate.

Example, replacing only the website base URL and leaving everything else intact:

```
{
    "website_base_url" : "http://my-own-festapp-server.herokuapp.com"
}
```

JSON was chosen as the file format to simplify parsing as parsing XML is much more complex with zero benefit over plain JSON. The URLUtil class is a singleton but accessing its instance requires a Context object for (possible) initialization and to avoid having to subclass Application separately to get hold of a Context.
