### PR TITLE
URL suffix fix

### DIFF
--- a/src/com/futurice/festapp/util/FestAppConstants.java
+++ b/src/com/futurice/festapp/util/FestAppConstants.java
@@ -5,14 +5,14 @@ public class FestAppConstants {
 	public static final String WEBSITE_BASE_URL = "http://festapp-server.herokuapp.com/";
 	
 	public static final String BASE_URL = "http://festapp-server.herokuapp.com";
-	public static final String NEWS_JSON_URL = "/api/news";
-	public static final String GIGS_JSON_URL = "/api/artists";
-	public static final String TRANSPORTATION_HTML_URL = "/api/arrival";
-	public static final String SERVICES_JSON_URL = "/api/services";
+	public static final String NEWS_JSON_URL = "/api/v1/news";
+	public static final String GIGS_JSON_URL = "/api/v1/artists";
+	public static final String TRANSPORTATION_HTML_URL = "/api/v1/arrival";  //not implemented in backend yet
+	public static final String SERVICES_JSON_URL = "/api/v1/services";  //not implemented in backend yet
 	public static final String STAGES_JSON_URL = "/api/v1/locations";
 	
-	public static final String FREQUENTLY_ASKED_QUESTIONS_JSON_URL = "/api/info";
-	public static final String FOOD_AND_DRINK_HTML_URL =  "/api/program";
+	public static final String FREQUENTLY_ASKED_QUESTIONS_JSON_URL = "/api/v1/info";
+	public static final String FOOD_AND_DRINK_HTML_URL =  "/api/v1/program";   //not implemented in backend yet
 	
 	public static final String DRAWABLE_ARTIST_LOGO_PREFIX = "artist_";
 	public static final String DRAWABLE_GUITAR_STRING_PREFIX = "guitar_string_";


### PR DESCRIPTION
URLs specified in FestAppConstants.java were wrong, and no data was being fetched from the backend because of this. Some features aren't yet supported by the backend and comments were added to the URLs of these features to indicate the problem (the application is functional despite of this, but obviously the data corresponding to these features won't be updated).
